### PR TITLE
I removed the need for `next_class`

### DIFF
--- a/test_path.py
+++ b/test_path.py
@@ -604,6 +604,7 @@ class ScratchDirTestCase(unittest.TestCase):
                       "should not raise an exception.")
 
 class TempDirTestCase(unittest.TestCase):
+
     def test_constructor(self):
         """
         One should be able to readily construct a temporary directory
@@ -622,7 +623,7 @@ class TempDirTestCase(unittest.TestCase):
         """
         d = tempdir()
         res = d.__enter__()
-        assert res is d
+        assert path(res) == path(d)
         (d / 'somefile.txt').touch()
         assert not isinstance(d / 'somefile.txt', tempdir)
         d.__exit__(None, None, None)
@@ -638,6 +639,18 @@ class TempDirTestCase(unittest.TestCase):
         assert not isinstance(d / 'somefile.txt', tempdir)
         d.__exit__(TypeError, TypeError('foo'), None)
         assert d.exists()
+
+
+    def test_context_manager_using_with(self):
+        """
+            The context manager will allow using the with keyword and
+            provide a temporry directory that will be deleted after that.
+        """
+
+        with tempdir() as d:
+            self.assertTrue(d.isdir())
+        self.assertFalse(d.isdir())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It comes with the cost of a small overhead at the context manager init since we create a path object a second time but I believe it's compensated by the fact we avoid a call to self.next_class everytime.

Unit tests pass, and I added one to test how it works with the `with keyword`. I also added an usage example in the docstring.
