### PR TITLE
Ignore DeprecationWarning caused by instantiating path on python2.6

### DIFF
--- a/path.py
+++ b/path.py
@@ -69,6 +69,8 @@ except ImportError:
 __version__ = '3.0'
 __all__ = ['path']
 
+warnings.simplefilter('ignore', DeprecationWarning, 116)
+
 class TreeWalkWarning(Warning):
     pass
 


### PR DESCRIPTION
Python2.6's class hierarchy is a bit different than 2.7 and the basic
init line causes a DeprecationWarning:

path.py:114: DeprecationWarning: object.**init**() takes no parameters
  super(path, self).**init**(self, other)

Add a warnings.simplefilter to ignore it as everything works fine
anyways.
