### PR TITLE
Don't add getcwdu back to os module

### DIFF
--- a/path.py
+++ b/path.py
@@ -84,9 +84,9 @@ except NameError:
     unicode = str
 
 try:
-    os.getcwdu
+    getcwdu = os.getcwdu
 except AttributeError:
-    os.getcwdu = os.getcwd
+    getcwdu = os.getcwd
 
 if sys.version < '3':
     def u(x):
@@ -222,7 +222,7 @@ class path(unicode):
 
         .. seealso:: :func:`os.getcwdu`
         """
-        return cls(os.getcwdu())
+        return cls(getcwdu())
 
     #
     # --- Operations on path strings.


### PR DESCRIPTION
This defines getcwdu locally rather than storing it in the `os` module, if it is not defined (i.e. on Python 3). IPython uses path.py, and this was masking problems with our code on Python 3.
