### PR TITLE
Correcting just minor pep8 violations

### DIFF
--- a/path.py
+++ b/path.py
@@ -1363,7 +1363,7 @@ class path(unicode):
     # http://www.zopatista.com/python/2013/11/26/inplace-file-rewriting/
     @contextlib.contextmanager
     def in_place(self, mode='r', buffering=-1, encoding=None, errors=None,
-            newline=None, backup_extension=None):
+                 newline=None, backup_extension=None):
         """
         A context in which a file may be re-written in-place with new content.
 
@@ -1401,21 +1401,21 @@ class path(unicode):
             pass
         os.rename(self, backup_fn)
         readable = io.open(backup_fn, mode, buffering=buffering,
-            encoding=encoding, errors=errors, newline=newline)
+                           encoding=encoding, errors=errors, newline=newline)
         try:
             perm = os.fstat(readable.fileno()).st_mode
         except OSError:
             writable = open(self, 'w' + mode.replace('r', ''),
-                buffering=buffering, encoding=encoding, errors=errors,
-                newline=newline)
+                            buffering=buffering, encoding=encoding,
+                            errors=errors, newline=newline)
         else:
             os_mode = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
             if hasattr(os, 'O_BINARY'):
                 os_mode |= os.O_BINARY
             fd = os.open(self, os_mode, perm)
             writable = io.open(fd, "w" + mode.replace('r', ''),
-                buffering=buffering, encoding=encoding, errors=errors,
-                newline=newline)
+                               buffering=buffering, encoding=encoding,
+                               errors=errors, newline=newline)
             try:
                 if hasattr(os, 'chmod'):
                     os.chmod(self, perm)

--- a/test_path.py
+++ b/test_path.py
@@ -871,8 +871,9 @@ class TestPatternMatching(object):
         assert p/'sub2'/'foo'/'bar.TXT' in files
         assert p/'sub1'/'foo'/'bar.Txt' in files
 
+
 @pytest.mark.skipif(sys.version_info < (2, 6),
-    reason="in_place requires io module in Python 2.6")
+                    reason="in_place requires io module in Python 2.6")
 class TestInPlace(object):
     reference_content = u(textwrap.dedent("""
         The quick brown fox jumped over the lazy dog.


### PR DESCRIPTION
While going through, the path.py source code I noticed a few minor pep8 violations, so I thought I would contribute by removing them.
