### PR TITLE
Add a .parents attibute to get the n-th parent

### DIFF
--- a/path.py
+++ b/path.py
@@ -343,6 +343,27 @@ class path(unicode):
         .. seealso:: :meth:`basename`, :func:`os.path.basename`
         """)
 
+    @property
+    def parents(self):
+        """A list of this path's parents. This is useful to find the n-th
+        parent of this path.
+
+        For example,
+        ``path('/usr/local/lib/libpython.so').parent[0] ==
+        path('/usr/local/lib')``,
+        ``path('/usr/local/lib/libpython.so').parent[1] ==
+        path('/usr/local')``,
+        ``path('/usr/local/lib/libpython.so').parent[2] == path('/usr')``
+        """
+        parents = [self.dirname()]
+        while parents[-1]:
+            next_parent = parents[-1].dirname()
+            if next_parent == parents[-1]:
+                # dirname("/") == "/"
+                break
+            parents.append(next_parent)
+        return parents
+
     def splitpath(self):
         """ p.splitpath() -> Return ``(p.parent, p.name)``.
 

--- a/test_path.py
+++ b/test_path.py
@@ -116,12 +116,23 @@ class BasicTestCase(unittest.TestCase):
     def testProperties(self):
         # Create sample path object.
         f = p(nt='C:\\Program Files\\Python\\Lib\\xyzzy.py',
-              posix='/usr/local/python/lib/xyzzy.py')
+              posix='/usr/python/lib/xyzzy.py')
         f = path(f)
 
         # .parent
         self.assertEqual(f.parent, p(nt='C:\\Program Files\\Python\\Lib',
-                                     posix='/usr/local/python/lib'))
+                                     posix='/usr/python/lib'))
+
+        # .parents
+        self.assertEqual(f.parents, [path(p(nt='C:\\Program Files\\Python\\Lib',
+                                            posix='/usr/python/lib')),
+                                     path(p(nt='C:\\Program Files\\Python',
+                                            posix='/usr/python')),
+                                     path(p(nt='C:\\Program Files',
+                                            posix='/usr')),
+                                     path(p(nt='C:\\',
+                                            posix='/')),
+                                     ])
 
         # .name
         self.assertEqual(f.name, 'xyzzy.py')


### PR DESCRIPTION
I used a list rather than a sequence for 2 reasons:

```
Simplicity
This way it is possible to get the len() of .parents
```

It was tested on Unix (Linux) only, I hope it works for windows too.

Closes #54
