### PR TITLE
chown now accepts names in addition to id for user and group

### DIFF
--- a/path.py
+++ b/path.py
@@ -62,6 +62,11 @@ try:
 except ImportError:
     pass
 
+try:
+    import grp
+except ImportError:
+    pass
+
 ################################
 # Monkey patchy python 3 support
 try:
@@ -922,10 +927,10 @@ class path(unicode):
                 :meth:`file.writelines`.
 
         Use the keyword argument ``append=True`` to append lines to the
-        file.  The default is to overwrite the file.  
-        
+        file.  The default is to overwrite the file.
+
         .. warning ::
-        
+
             When you use this with Unicode data, if the encoding of the
             existing data in the file is different from the encoding
             you specify with the `encoding=` parameter, the result is
@@ -1175,6 +1180,10 @@ class path(unicode):
     if hasattr(os, 'chown'):
         def chown(self, uid=-1, gid=-1):
             """ .. seealso:: :func:`os.chown` """
+            if 'pwd' in globals() and isinstance(uid, basestring):
+                uid = pwd.getpwnam(uid).pw_uid
+            if 'grp' in globals() and isinstance(gid, basestring):
+                gid = grp.getgrnam(gid).gr_gid
             os.chown(self, uid, gid)
             return self
 


### PR DESCRIPTION
I played it safe, maybe too much...

Note that this behavior is present in shutils since python3.3.

Closes #31
