### PR TITLE
Enhanced open

### DIFF
--- a/path.py
+++ b/path.py
@@ -699,8 +699,8 @@ class Path(text_type):
              newline=None):
         """ Open this file and return a corresponding :class:`file` object.
 
-        Keywords arguments work as in io.open.  If the file cannot be
-        opened, an OSError is raised.
+        Keyword arguments work as in :func:`io.open`.  If the file cannot be
+        opened, an :class:`~exceptions.OSError` is raised.
         """
         try:
             return io.open(self, mode=mode, buffering=buffering,
@@ -751,7 +751,9 @@ class Path(text_type):
 
     def text(self, encoding=None, errors='strict'):
         r""" Open this file, read it in, return the content as a string.
-             All newline sequences are converted to ``'\n'``.
+
+        All newline sequences are converted to ``'\n'``.  Keyword arguments
+        will be passed to :meth:`open`.
 
         .. seealso:: :meth:`lines`
         """


### PR DESCRIPTION
This PR changes the `open` method to use `io.open` (note that in Python 3 the latter is just an alias for the `open` built-in function). All methods that used the `open` built-in function directly have been changed to use `Path.open` instead, so that a subclass only has to override one method to implement a customized open.

In addition, newline patterns have been moved to module-level variables, and regular expression matching is used for removal and replacement. This makes related code more efficient, compact and easier to maintain.
