### PR TITLE
Move documentation to 'path.readthedocs.io'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@
 .. image:: https://img.shields.io/appveyor/ci/jaraco/path/master.svg
    :target: https://ci.appveyor.com/project/jaraco/path/branch/master
 
-.. image:: https://readthedocs.org/projects/pathpy/badge/?version=latest
-   :target: https://pathpy.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/path/badge/?version=latest
+   :target: https://path.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://tidelift.com/badges/package/pypi/path
    :target: https://tidelift.com/subscription/pkg/pypi-path?utm_source=pypi-path&utm_medium=readme
@@ -45,7 +45,7 @@ files to be invoked on those path objects directly. For example:
 
 Path pie is `hosted at Github <https://github.com/jaraco/path>`_.
 
-Find `the documentation here <https://pathpy.readthedocs.io>`_.
+Find `the documentation here <https://path.readthedocs.io>`_.
 
 Guides and Testimonials
 =======================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to Path Pie's documentation!
-===================================
+====================================
 
 Contents:
 
@@ -8,6 +8,10 @@ Contents:
 
    api
    history
+
+Thanks to Mahan Marwat for transferring the ``path`` name on
+Read The Docs from `path <https://github.com/mahanmarwat/path>`_
+to this project.
 
 
 Indices and tables


### PR DESCRIPTION
@mahanmarwat has generously offered to transfer the name 'path.readthedocs.io' to this project. Once I have admin access to that project in RTD (or it is deleted), I'll build the docs there, and these changes will point users to that URL for docs.