### PR TITLE
test_list_dir_other_encoding: replace `skip` with `skipif`

### DIFF
--- a/test_path.py
+++ b/test_path.py
@@ -415,7 +415,7 @@ class TestScratchDir:
                 except Exception:
                     pass
 
-    @pytest.mark.skip(
+    @pytest.mark.skipif(
         platform.system() != "Linux",
         reason="Only Linux allows writing invalid encodings",
     )


### PR DESCRIPTION
The `skip` markers always skips the test, here we still want the
test to run when on Linux.