### PR TITLE
Change hash example to use SHA-256

### DIFF
--- a/path/__init__.py
+++ b/path/__init__.py
@@ -806,7 +806,7 @@ class Path(str):
 
         :example:
 
-            >>> hash = hashlib.md5()
+            >>> hash = hashlib.sha256()
             >>> for chunk in Path("NEWS.rst").chunks(8192, mode='rb'):
             ...     hash.update(chunk)
 


### PR DESCRIPTION
With the previous md5 example, building and testing this package with FIPS fails on doctest:

```
809     >>> hash = hashlib.md5()
UNEXPECTED EXCEPTION: UnsupportedDigestmodError('[digital envelope routines] unsupported')
```

So I updated example to use hashlib.sha256 instead of hashlib.md5.

(ref our internal ticket DSP-63)

Closes #240 