### PR TITLE
fix: `Path.cwd()` is missing a return type annotation

### DIFF
--- a/path/__init__.py
+++ b/path/__init__.py
@@ -251,7 +251,7 @@ class Path(str):
         os.chdir(self._old_dir)
 
     @classmethod
-    def cwd(cls):
+    def cwd(cls) -> 'Path':
         """Return the current working directory as a path object.
 
         .. seealso:: :func:`os.getcwd`


### PR DESCRIPTION
Fixes #243

`Path.cwd()` in `path/__init__.py` lacked a return type annotation, leaving type checkers unable to infer the return type. The root cause was a missing `-> 'Path'` annotation on the classmethod definition. Adds the annotation to `Path.cwd()` in `path/__init__.py`, using a forward reference string `'Path'` consistent with the class's own type. Verified by running the module and confirming `Path.cwd()` returns a `Path` instance without errors.