### PR TITLE
fix: `pygments` and `types-pywin32` should be moved to extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ test = [
 	"packaging",
 	'pywin32; platform_system == "Windows" and python_version < "3.12"',
 	"more_itertools",
-	# required for checkdocs on README.rst
-	"pygments",
-	"types-pywin32",
 ]
 
 doc = [
@@ -66,6 +63,7 @@ doc = [
 check = [
 	"pytest-checkdocs >= 2.4",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
+	"pygments",
 ]
 
 cover = [
@@ -81,6 +79,7 @@ type = [
 	"pytest-mypy",
 
 	# local
+	"types-pywin32",
 ]
 
 


### PR DESCRIPTION
Fixes #241

`pygments` and `types-pywin32` were listed under the `test` extras in `pyproject.toml`, but neither is required for running tests. `pygments` is needed by `pytest-checkdocs` for README.rst validation, and `types-pywin32` provides type stubs for mypy. Moves `pygments` to the `check` extras and `types-pywin32` to the `type` extras, aligning each dependency with the tooling that actually requires it. Verified by confirming no regressions in the existing test and lint pipeline.